### PR TITLE
worker builder error update

### DIFF
--- a/app/src/main/java/com/latticeonfhir/android/service/workmanager/request/WorkRequestBuilders.kt
+++ b/app/src/main/java/com/latticeonfhir/android/service/workmanager/request/WorkRequestBuilders.kt
@@ -53,16 +53,18 @@ class WorkRequestBuilders(
             )
         ).collectLatest { workInfo ->
             if (workInfo != null) {
-                if (workInfo.state == WorkInfo.State.FAILED) error(
-                    true,
-                    workInfo.outputData.keyValueMap["errorMsg"].toString()
-                )
-                else {
+                if (workInfo.state == WorkInfo.State.FAILED) {
+                    val errorMsg = workInfo.outputData.keyValueMap["errorMsg"].toString()
+                    if (errorMsg == ErrorConstants.SESSION_EXPIRED || errorMsg == ErrorConstants.UNAUTHORIZED) error(
+                        true,
+                        errorMsg
+                    )
+                } else {
                     val progress = workInfo.progress
                     val value = progress.getInt(PatientUploadSyncWorker.PatientUploadProgress, 0)
                     if (value == 100) {
                         /** Update Fhir Id in Generic Entity */
-                        updateFhirIdInRelation(){ errorReceived, errorMsg ->
+                        updateFhirIdInRelation() { errorReceived, errorMsg ->
                             error(errorReceived, errorMsg)
                         }
                     }
@@ -87,8 +89,11 @@ class WorkRequestBuilders(
             )
         ).collectLatest { workInfo ->
             if (workInfo?.state == WorkInfo.State.FAILED) {
-                error(true,
-                    workInfo.outputData.keyValueMap["errorMsg"].toString())
+                val errorMsg = workInfo.outputData.keyValueMap["errorMsg"].toString()
+                if (errorMsg == ErrorConstants.SESSION_EXPIRED || errorMsg == ErrorConstants.UNAUTHORIZED) error(
+                    true,
+                    errorMsg
+                )
             } else if (workInfo?.state == WorkInfo.State.SUCCEEDED) {
                 downloadRelationWorker { errorReceived, errorMsg ->
                     error(errorReceived, errorMsg)
@@ -108,11 +113,13 @@ class WorkRequestBuilders(
             )
         ).collectLatest { workInfo ->
             if (workInfo != null) {
-                if (workInfo.state == WorkInfo.State.FAILED) error(
-                    true,
-                    workInfo.outputData.keyValueMap["errorMsg"].toString()
-                )
-                else {
+                if (workInfo.state == WorkInfo.State.FAILED) {
+                    val errorMsg = workInfo.outputData.keyValueMap["errorMsg"].toString()
+                    if (errorMsg == ErrorConstants.SESSION_EXPIRED || errorMsg == ErrorConstants.UNAUTHORIZED) error(
+                        true,
+                        errorMsg
+                    )
+                } else {
                     val progress = workInfo.progress
                     val value = progress.getInt(RelationUploadSyncWorker.RelationUploadProgress, 0)
                     if (value == 100) {
@@ -141,10 +148,13 @@ class WorkRequestBuilders(
             )
         ).collectLatest { workInfo ->
             if (workInfo != null) {
-                if (workInfo.state == WorkInfo.State.FAILED) error(
-                    true,
-                    workInfo.outputData.keyValueMap["errorMsg"].toString()
-                )
+                if (workInfo.state == WorkInfo.State.FAILED) {
+                    val errorMsg = workInfo.outputData.keyValueMap["errorMsg"].toString()
+                    if (errorMsg == ErrorConstants.SESSION_EXPIRED || errorMsg == ErrorConstants.UNAUTHORIZED) error(
+                        true,
+                        errorMsg
+                    )
+                }
             }
         }
     }
@@ -163,11 +173,13 @@ class WorkRequestBuilders(
             )
         ).collectLatest { workInfo ->
             if (workInfo != null) {
-                if (workInfo.state == WorkInfo.State.FAILED) error(
-                    true,
-                    workInfo.outputData.keyValueMap["errorMsg"].toString()
-                )
-                else {
+                if (workInfo.state == WorkInfo.State.FAILED) {
+                    val errorMsg = workInfo.outputData.keyValueMap["errorMsg"].toString()
+                    if (errorMsg == ErrorConstants.SESSION_EXPIRED || errorMsg == ErrorConstants.UNAUTHORIZED) error(
+                        true,
+                        errorMsg
+                    )
+                } else {
                     val progress = workInfo.progress
                     val value = progress.getInt(PatientPatchUploadSyncWorker.PatientPatchUpload, 0)
                     if (value == 100) {
@@ -195,11 +207,13 @@ class WorkRequestBuilders(
             )
         ).collectLatest { workInfo ->
             if (workInfo != null) {
-                if (workInfo.state == WorkInfo.State.FAILED) error(
-                    true,
-                    workInfo.outputData.keyValueMap["errorMsg"].toString()
-                )
-                else {
+                if (workInfo.state == WorkInfo.State.FAILED) {
+                    val errorMsg = workInfo.outputData.keyValueMap["errorMsg"].toString()
+                    if (errorMsg == ErrorConstants.SESSION_EXPIRED || errorMsg == ErrorConstants.UNAUTHORIZED) error(
+                        true,
+                        errorMsg
+                    )
+                } else {
                     val progress = workInfo.progress
                     val value =
                         progress.getInt(RelationPatchUploadSyncWorker.RelationPatchUpload, 0)


### PR DESCRIPTION
## Guidelines
- It is mandatory to assign a reviewer to PR
- A Pull Request must always refer to single or related usecase. Non related usecases must not be a part of same Pull request
- If a Pull Request has mix of type of changes then the description section must point to relevent information for each type `Note : We must avoid merging multiple changes in a single PR`
  - Bug Fix : Point to all issue id's of the bugs fixed. One commit mapped to one bug id. Do not fix multiple bugs in a single commit
  - New Feature: Must point to a usecase or relevent documentation bug
  - Enhancement: Must point to a usecase or relevent documentation bug
  - Refactoring: The context of why the refactoring has been done. 

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
added condition to check the error message provided by server to log out the user.
only when the error message is "Session expired." or "Unauthorized" then the user will be logged out.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
For UI related change
Mobile screen config  5.0''; 1080 x 1920; 420dpi
Tablet screen config 10.1''; 800 x 1280; mdpi

| ScreenType|  GIF/Screenshot  |
|---|---|
| Mobile-potrait  |  <img src="https://user-images.githubusercontent.com/5468111/82522760-07db8900-9b48-11ea-8b7b-43ca1a0a425a.gif" width="260"> |
| Mobile-landscape   |<img src="https://user-images.githubusercontent.com/5468111/82523184-0363a000-9b49-11ea-8a92-2231a585c13c.gif" width="600">   |
-->
