### PR TITLE
Forced sync on landing screen to display list after update

### DIFF
--- a/app/src/main/java/com/latticeonfhir/android/service/workmanager/workers/trigger/TriggerWorkerPeriodic.kt
+++ b/app/src/main/java/com/latticeonfhir/android/service/workmanager/workers/trigger/TriggerWorkerPeriodic.kt
@@ -3,33 +3,12 @@ package com.latticeonfhir.android.service.workmanager.workers.trigger
 import android.content.Context
 import androidx.work.WorkerParameters
 import com.latticeonfhir.android.FhirApp
-import com.latticeonfhir.android.data.local.enums.WorkerStatus
 import com.latticeonfhir.android.service.workmanager.workers.base.SyncWorker
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 abstract class TriggerWorkerPeriodic(context: Context, workerParameters: WorkerParameters) :
     SyncWorker(context, workerParameters) {
     override suspend fun doWork(): Result {
-        val listOfErrors = mutableListOf<String>()
-        (applicationContext as FhirApp).syncWorkerStatus.postValue(WorkerStatus.IN_PROGRESS)
-        (applicationContext as FhirApp).syncService
-            .syncLauncher { errorReceived, errorMessage ->
-                // as there will be multiple callbacks from different coroutines
-                // list of errors is maintained.
-                // if the list is empty, then all the api calls were successful.
-                listOfErrors.add(errorMessage)
-                (applicationContext as FhirApp).syncWorkerStatus.postValue(WorkerStatus.FAILED)
-                CoroutineScope(Dispatchers.Main).launch {
-                    (applicationContext as FhirApp).sessionExpireFlow.postValue(
-                        mapOf(Pair("errorReceived", errorReceived), Pair("errorMsg", errorMessage))
-                    )
-                }
-            }.also {
-                if(listOfErrors.isEmpty()) (applicationContext as FhirApp).syncWorkerStatus.postValue(WorkerStatus.SUCCESS)
-                else (applicationContext as FhirApp).syncWorkerStatus.postValue(WorkerStatus.FAILED)
-            }
+        (applicationContext as FhirApp).launchSyncing()
         return Result.success()
     }
 }

--- a/app/src/main/java/com/latticeonfhir/android/ui/landingscreen/LandingScreen.kt
+++ b/app/src/main/java/com/latticeonfhir/android/ui/landingscreen/LandingScreen.kt
@@ -120,6 +120,7 @@ fun LandingScreen(
     }
     LaunchedEffect(viewModel.isLaunched) {
         if (!viewModel.isLaunched) {
+            viewModel.syncData()
             viewModel.selectedIndex =
                 navController.previousBackStackEntry?.savedStateHandle?.get<Int>(
                     SELECTED_INDEX

--- a/app/src/main/java/com/latticeonfhir/android/ui/landingscreen/QueueViewModel.kt
+++ b/app/src/main/java/com/latticeonfhir/android/ui/landingscreen/QueueViewModel.kt
@@ -67,20 +67,11 @@ class QueueViewModel @Inject constructor(
     var selectedChip by mutableIntStateOf(R.string.total_appointment)
     var rescheduled by mutableStateOf(false)
 
-    private val syncService by lazy { getApplication<FhirApp>().syncService }
-
     internal suspend fun syncData(ioDispatcher: CoroutineDispatcher = Dispatchers.IO) {
         getWorkerInfo<TriggerWorkerPeriodicImpl>(getApplication<FhirApp>().applicationContext).collectLatest { workInfo ->
             if (workInfo != null && workInfo.state == WorkInfo.State.ENQUEUED) {
                 withContext(ioDispatcher) {
-                    syncService.syncLauncher { errorReceived, errorMessage ->
-                        getApplication<FhirApp>().sessionExpireFlow.postValue(
-                            mapOf(
-                                Pair("errorReceived", errorReceived),
-                                Pair("errorMsg", errorMessage)
-                            )
-                        )
-                    }
+                    getApplication<FhirApp>().launchSyncing()
                     getAppointmentListByDate(ioDispatcher)
                 }
             }

--- a/app/src/main/java/com/latticeonfhir/android/ui/login/OtpScreen.kt
+++ b/app/src/main/java/com/latticeonfhir/android/ui/login/OtpScreen.kt
@@ -80,7 +80,10 @@ fun OtpScreen(navController: NavController, viewModel: OtpViewModel = hiltViewMo
     }
     LaunchedEffect(activity.otp) {
         if (activity.otp.isNotEmpty()) {
-            viewModel.otpEntered = activity.otp
+            activity.otp.trim().forEachIndexed { index, c ->
+                viewModel.otpValues[index].value = c.toString()
+            }
+            viewModel.updateOtp()
             verifyClick(navController, viewModel)
             activity.otp = ""
             activity.unregisterBroadcastReceiver()

--- a/app/src/main/java/com/latticeonfhir/android/ui/patientlandingscreen/PatientLandingScreenViewModel.kt
+++ b/app/src/main/java/com/latticeonfhir/android/ui/patientlandingscreen/PatientLandingScreenViewModel.kt
@@ -51,12 +51,7 @@ class PatientLandingScreenViewModel @Inject constructor(
             Sync.getWorkerInfo<TriggerWorkerPeriodicImpl>(getApplication<FhirApp>().applicationContext)
                 .collectLatest { workInfo ->
                     if (workInfo != null && workInfo.state == WorkInfo.State.ENQUEUED) {
-                        syncService.syncLauncher { isErrorReceived, errorMsg ->
-                            if (isErrorReceived) {
-                                logoutUser = true
-                                logoutReason = errorMsg
-                            }
-                        }
+                        getApplication<FhirApp>().launchSyncing()
                     }
                 }
         }


### PR DESCRIPTION
## Guidelines
- It is mandatory to assign a reviewer to PR
- A Pull Request must always refer to single or related usecase. Non related usecases must not be a part of same Pull request
- If a Pull Request has mix of type of changes then the description section must point to relevent information for each type `Note : We must avoid merging multiple changes in a single PR`
  - Bug Fix : Point to all issue id's of the bugs fixed. One commit mapped to one bug id. Do not fix multiple bugs in a single commit
  - New Feature: Must point to a usecase or relevent documentation bug
  - Enhancement: Must point to a usecase or relevent documentation bug
  - Refactoring: The context of why the refactoring has been done. 

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Forced sync on landing screen to display list after updating to latest version.
https://github.com/LatticeInnovations/LatticeOnFhirMain/issues/333

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
For UI related change
Mobile screen config  5.0''; 1080 x 1920; 420dpi
Tablet screen config 10.1''; 800 x 1280; mdpi

| ScreenType|  GIF/Screenshot  |
|---|---|
| Mobile-potrait  |  <img src="https://user-images.githubusercontent.com/5468111/82522760-07db8900-9b48-11ea-8b7b-43ca1a0a425a.gif" width="260"> |
| Mobile-landscape   |<img src="https://user-images.githubusercontent.com/5468111/82523184-0363a000-9b49-11ea-8a92-2231a585c13c.gif" width="600">   |
-->
