### PR TITLE
Remove Base Url

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,14 +81,14 @@ android {
             shrinkResources false
             testCoverageEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            buildConfigField "String", "BASE_URL", "\"https://fhir.api.thelattice.org/facadeDev/api/v1/\""
+            buildConfigField "String", "BASE_URL", "\"YOUR_DEBUG_SERVER_URL\""
             // dev
         }
         release {
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            buildConfigField "String", "BASE_URL", "\"https://fhir.api.thelattice.org/facadeDev/api/v1/\""
+            buildConfigField "String", "BASE_URL", "\"YOUR_PRODUCTION_SERVER_URL\""
             // test
             signingConfig signingConfigs.release
         }


### PR DESCRIPTION
## Guidelines
- It is mandatory to assign a reviewer to PR
- A Pull Request must always refer to single or related usecase. Non related usecases must not be a part of same Pull request
- If a Pull Request has mix of type of changes then the description section must point to relevent information for each type `Note : We must avoid merging multiple changes in a single PR`
  - Bug Fix : Point to all issue id's of the bugs fixed. One commit mapped to one bug id. Do not fix multiple bugs in a single commit
  - New Feature: Must point to a usecase or relevent documentation bug
  - Enhancement: Must point to a usecase or relevent documentation bug
  - Refactoring: The context of why the refactoring has been done. 

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
https://github.com/LatticeInnovations/LatticeOnFhirMain/issues/1091

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/LatticeInnovations/LatticeOnFhirMain/issues/1091

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
For UI related change
Mobile screen config  5.0''; 1080 x 1920; 420dpi
Tablet screen config 10.1''; 800 x 1280; mdpi

| ScreenType|  GIF/Screenshot  |
|---|---|
| Mobile-potrait  |  <img src="https://user-images.githubusercontent.com/5468111/82522760-07db8900-9b48-11ea-8b7b-43ca1a0a425a.gif" width="260"> |
| Mobile-landscape   |<img src="https://user-images.githubusercontent.com/5468111/82523184-0363a000-9b49-11ea-8a92-2231a585c13c.gif" width="600">   |
-->
