### PR TITLE
Removed reorder library 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -238,9 +238,6 @@ dependencies {
     implementation 'com.google.android.gms:play-services-auth:21.3.0'
     implementation 'com.google.android.gms:play-services-auth-api-phone:18.2.0'
 
-    // reordering in lazy column list
-    implementation("org.burnoutcrew.composereorderable:reorderable:0.9.6")
-
     // glide
     implementation("com.github.bumptech.glide:glide:4.14.2")
 

--- a/app/src/main/java/com/latticeonfhir/android/ui/landingscreen/QueueScreen.kt
+++ b/app/src/main/java/com/latticeonfhir/android/ui/landingscreen/QueueScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -95,9 +96,6 @@ import com.latticeonfhir.android.utils.converters.responseconverter.TimeConverte
 import com.latticeonfhir.android.utils.converters.responseconverter.TimeConverter.toTodayStartDate
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import org.burnoutcrew.reorderable.ReorderableItem
-import org.burnoutcrew.reorderable.rememberReorderableLazyListState
-import org.burnoutcrew.reorderable.reorderable
 import java.util.Date
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -112,13 +110,7 @@ fun QueueScreen(
     viewModel: QueueViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
-    val queueListState = rememberReorderableLazyListState(onMove = { from, to ->
-        if (to.index > 0 && to.index <= viewModel.waitingQueueList.size && from.index > 0 && from.index <= viewModel.waitingQueueList.size) {
-            viewModel.waitingQueueList = viewModel.waitingQueueList.toMutableList().apply {
-                add(to.index - 1, removeAt(from.index - 1))
-            }
-        }
-    })
+    val queueListState = rememberLazyListState()
     viewModel.rescheduled = navController.currentBackStackEntry?.savedStateHandle?.get<Boolean>(
         NavControllerConstants.RESCHEDULED
     ) == true
@@ -145,7 +137,7 @@ fun QueueScreen(
         modifier = Modifier
             .fillMaxSize()
     ) {
-        AnimatedVisibility(queueListState.listState.firstVisibleItemScrollOffset == 0 && queueListState.listState.firstVisibleItemIndex == 0) {
+        AnimatedVisibility(queueListState.firstVisibleItemScrollOffset == 0 && queueListState.firstVisibleItemIndex == 0) {
             WeekDaysComposable(
                 dateScrollState,
                 viewModel.selectedDate,
@@ -194,7 +186,7 @@ fun QueueScreen(
                     AppointmentStatusChips(
                         R.string.total_appointment,
                         viewModel.appointmentsList.size,
-                        queueListState.listState,
+                        queueListState,
                         coroutineScope,
                         0,
                         viewModel
@@ -203,7 +195,7 @@ fun QueueScreen(
                         AppointmentStatusChips(
                             R.string.waiting_appointment,
                             viewModel.waitingQueueList.size,
-                            queueListState.listState,
+                            queueListState,
                             coroutineScope,
                             0,
                             viewModel
@@ -212,7 +204,7 @@ fun QueueScreen(
                         AppointmentStatusChips(
                             R.string.in_progress_appointment,
                             viewModel.inProgressQueueList.size,
-                            queueListState.listState,
+                            queueListState,
                             coroutineScope,
                             if (viewModel.waitingQueueList.isNotEmpty()) 1 else 0,
                             viewModel
@@ -226,7 +218,7 @@ fun QueueScreen(
                         AppointmentStatusChips(
                             R.string.scheduled_appointment,
                             viewModel.scheduledQueueList.size,
-                            queueListState.listState,
+                            queueListState,
                             coroutineScope,
                             viewModel.inProgressQueueList.size + if (viewModel.waitingQueueList.isNotEmpty()) 1 else 0,
                             viewModel
@@ -234,7 +226,7 @@ fun QueueScreen(
                         AppointmentStatusChips(
                             R.string.completed_appointment,
                             viewModel.completedQueueList.size,
-                            queueListState.listState,
+                            queueListState,
                             coroutineScope,
                             viewModel.inProgressQueueList.size + viewModel.scheduledQueueList.size + if (viewModel.waitingQueueList.isNotEmpty()) 1 else 0,
                             viewModel
@@ -242,7 +234,7 @@ fun QueueScreen(
                         AppointmentStatusChips(
                             R.string.cancelled_appointment,
                             viewModel.cancelledQueueList.size,
-                            queueListState.listState,
+                            queueListState,
                             coroutineScope,
                             viewModel.inProgressQueueList.size + viewModel.scheduledQueueList.size + viewModel.completedQueueList.size + if (viewModel.waitingQueueList.isNotEmpty()) 1 else 0,
                             viewModel
@@ -250,9 +242,7 @@ fun QueueScreen(
                     }
             }
             LazyColumn(
-                state = queueListState.listState,
-                modifier = Modifier
-                    .reorderable(queueListState),
+                state = queueListState,
                 content = {
                     if (viewModel.waitingQueueList.isNotEmpty())
                         item {
@@ -278,35 +268,29 @@ fun QueueScreen(
                                         color = MaterialTheme.colorScheme.outline
                                     )
                                     viewModel.waitingQueueList.forEach { waitingAppointmentResponse ->
-                                        ReorderableItem(
-                                            queueListState, key = waitingAppointmentResponse,
-                                            modifier = Modifier
-                                                .background(MaterialTheme.colorScheme.secondaryContainer)
-                                        ) { _ ->
-                                            var patient by remember {
-                                                mutableStateOf<PatientResponse?>(null)
-                                            }
-                                            waitingAppointmentResponse.patientId.let { patientId ->
-                                                LaunchedEffect(key1 = patientId) {
-                                                    patient = viewModel.getPatientById(
-                                                        patientId
-                                                    )
-                                                }
-                                            }
-                                            Row(
-                                                modifier = Modifier
-                                                    .fillMaxWidth()
-                                                    .padding(vertical = 9.dp),
-                                                horizontalArrangement = Arrangement.SpaceBetween
-                                            ) {
-                                                QueuePatientCard(
-                                                    navController,
-                                                    viewModel,
-                                                    landingViewModel,
-                                                    waitingAppointmentResponse,
-                                                    patient
+                                        var patient by remember {
+                                            mutableStateOf<PatientResponse?>(null)
+                                        }
+                                        waitingAppointmentResponse.patientId.let { patientId ->
+                                            LaunchedEffect(key1 = patientId) {
+                                                patient = viewModel.getPatientById(
+                                                    patientId
                                                 )
                                             }
+                                        }
+                                        Row(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(vertical = 9.dp),
+                                            horizontalArrangement = Arrangement.SpaceBetween
+                                        ) {
+                                            QueuePatientCard(
+                                                navController,
+                                                viewModel,
+                                                landingViewModel,
+                                                waitingAppointmentResponse,
+                                                patient
+                                            )
                                         }
                                     }
                                 }


### PR DESCRIPTION
## Guidelines
- It is mandatory to assign a reviewer to PR
- A Pull Request must always refer to single or related usecase. Non related usecases must not be a part of same Pull request
- If a Pull Request has mix of type of changes then the description section must point to relevent information for each type `Note : We must avoid merging multiple changes in a single PR`
  - Bug Fix : Point to all issue id's of the bugs fixed. One commit mapped to one bug id. Do not fix multiple bugs in a single commit
  - New Feature: Must point to a usecase or relevent documentation bug
  - Enhancement: Must point to a usecase or relevent documentation bug
  - Refactoring: The context of why the refactoring has been done. 

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Removed reorder library as it was not used, and lower dependency of compose.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
For UI related change
Mobile screen config  5.0''; 1080 x 1920; 420dpi
Tablet screen config 10.1''; 800 x 1280; mdpi

| ScreenType|  GIF/Screenshot  |
|---|---|
| Mobile-potrait  |  <img src="https://user-images.githubusercontent.com/5468111/82522760-07db8900-9b48-11ea-8b7b-43ca1a0a425a.gif" width="260"> |
| Mobile-landscape   |<img src="https://user-images.githubusercontent.com/5468111/82523184-0363a000-9b49-11ea-8a92-2231a585c13c.gif" width="600">   |
-->
